### PR TITLE
Add code styling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2015 Kezz Bracey
+Copyright 2016 Kezz Bracey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ Base font size rem values are calculated with.
 Default: `/`
 
 the character used for unit conversion, don't wrap in quotes, e.g. change `/` to `->`
+
+[![js-happiness-style](https://cdn.rawgit.com/JedWatson/happiness/master/badge.svg)](https://github.com/JedWatson/happiness)

--- a/package.json
+++ b/package.json
@@ -13,11 +13,24 @@
     "url": "git://github.com/posthumans/postcss-rem-phi-units.git"
   },
   "scripts": {
-    "lint": "happiness ./postcss-rem-phi-units.js",
+    "lint": "npm-run-all lint:**",
+    "lint:eslint": "eslint ./postcss-rem-phi-units.js",
+    "lint:happiness": "happiness ./postcss-rem-phi-units.js",
     "test": "ava --verbose"
   },
   "devDependencies": {
     "happiness": "^5.5.0",
     "ava": "^0.11.0"
+  },
+  "eslintConfig": {
+    "extends": "eslint:recommended",
+    "env": {
+      "node": true
+    }
+  },
+  "devDependencies": {
+    "eslint": "^1.10.3",
+    "happiness": "^5.5.0",
+    "npm-run-all": "^1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-rem-phi-units",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Extra units for easy rem and phi based layouts",
   "main": "postcss-rem-phi-units.js",
   "author": "Kezz Bracey",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "npm-run-all lint:**",
     "lint:eslint": "eslint ./postcss-rem-phi-units.js",
     "lint:happiness": "happiness ./postcss-rem-phi-units.js",
-    "test": "ava --verbose"
+    "test": "npm-run-all lint ava",
+    "ava": "ava --verbose"
   },
   "devDependencies": {
     "ava": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "url": "git://github.com/posthumans/postcss-rem-phi-units.git"
   },
   "scripts": {
+    "lint": "happiness ./postcss-rem-phi-units.js",
     "test": "ava --verbose"
   },
   "devDependencies": {
+    "happiness": "^5.5.0",
     "ava": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,18 +19,15 @@
     "test": "ava --verbose"
   },
   "devDependencies": {
+    "ava": "^0.11.0",
+    "eslint": "^1.10.3",
     "happiness": "^5.5.0",
-    "ava": "^0.11.0"
+    "npm-run-all": "^1.5.1"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",
     "env": {
       "node": true
     }
-  },
-  "devDependencies": {
-    "eslint": "^1.10.3",
-    "happiness": "^5.5.0",
-    "npm-run-all": "^1.5.1"
   }
 }

--- a/postcss-rem-phi-units.js
+++ b/postcss-rem-phi-units.js
@@ -106,7 +106,7 @@ module.exports = postcss.plugin('remphiunits', function remphiunits (options) {
 
 		// Convert the rest of the units
 		css.walkRules(function (rule) {
-			rule.walkDecls(function (decl, i) {
+			rule.walkDecls(function (decl) {
 				var value = decl.value;
 
 				/* This can't be implemented without a way to pass the current element's font size to the em calculation */

--- a/postcss-rem-phi-units.js
+++ b/postcss-rem-phi-units.js
@@ -1,8 +1,5 @@
 var postcss = require('postcss');
 
-// Set value of phi
-var phi = 1.618;
-
 // Make these variables global
 var base_font_size;
 var precision;
@@ -28,30 +25,23 @@ var pxRemReplace = function ($1) {
 	// toFixed() is used so we don't have too many decimal points
 	// parseFloat() is applied to the resulting value so any trailing 0 decimals are removed
 	// Then a rem unit is appended at the end
-	return parseFloat( ( parseFloat($1) / base_font_size ).toFixed(precision) ) + 'rem';
+	return parseFloat((parseFloat($1) / base_font_size).toFixed(precision)) + 'rem';
 };
 
-var pxEmReplace = function ($1) {
-	return parseFloat( ( parseFloat($1) / base_font_size ).toFixed(precision) ) + 'em';
-};
-
-function escapeRegExp(str) {
-	return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+function escapeRegExp (str) {
+	return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
 
-module.exports = postcss.plugin('remphiunits', function remphiunits(options) {
-
+module.exports = postcss.plugin('remphiunits', function remphiunits (options) {
 	return function (css) {
-
 		// Set syntax for conversion units from settings, or go to defaults
 		options = options || {};
 		var convert_all_px = options['convert-all-px'] || false;
 		precision = options['precision'] || 3;
 		base_font_size = options['base-font-size'] || 16;
 		conversion_character = options['conversion-character'] || '/';
-				console.log(conversion_character)
 
-		conversion_character_escaped = escapeRegExp(conversion_character);
+		var conversion_character_escaped = escapeRegExp(conversion_character);
 
 		/*
 		* Allow the options to be overridden with at rules
@@ -67,18 +57,17 @@ module.exports = postcss.plugin('remphiunits', function remphiunits(options) {
 		css.walkAtRules('remphiunits', function (rule) {
 			rule.params = rule.params.split(' ');
 
-			if (rule.params[0] == 'convert-all-px') {
+			if (rule.params[0] === 'convert-all-px') {
 				convert_all_px = rule.params[1];
 			}
-			if (rule.params[0] == 'precision') {
+			if (rule.params[0] === 'precision') {
 				precision = rule.params[1];
 			}
-			if (rule.params[0] == 'base-font-size') {
+			if (rule.params[0] === 'base-font-size') {
 				base_font_size = rule.params[1];
 			}
-			if (rule.params[0] == 'conversion-character') {
+			if (rule.params[0] === 'conversion-character') {
 				conversion_character = rule.params[1];
-				console.log(conversion_character)
 				conversion_character_escaped = escapeRegExp(conversion_character);
 			}
 
@@ -88,12 +77,13 @@ module.exports = postcss.plugin('remphiunits', function remphiunits(options) {
 		// Setup conversion unit syntax and regex's we'll use later
 
 		// If convert-all-px option is set to true, make the syntax for px_to_rem 'px' so all px units will be converted
-		if (convert_all_px){
-			var px_to_rem = 'px';
-			var px_to_rem_regex = new RegExp(get_value + 'px', 'ig');
+		var px_to_rem, px_to_rem_regex;
+		if (convert_all_px) {
+			px_to_rem = 'px';
+			px_to_rem_regex = new RegExp(get_value + 'px', 'ig');
 		} else {
-			var px_to_rem = 'px' + conversion_character + 'rem';
-			var px_to_rem_regex = new RegExp(get_value + 'px' + conversion_character_escaped + 'rem', 'ig');
+			px_to_rem = 'px' + conversion_character + 'rem';
+			px_to_rem_regex = new RegExp(get_value + 'px' + conversion_character_escaped + 'rem', 'ig');
 		}
 
 		/* This can't be implemented without a way to pass the current element's font size to the em calculation */
@@ -116,9 +106,7 @@ module.exports = postcss.plugin('remphiunits', function remphiunits(options) {
 
 		// Convert the rest of the units
 		css.walkRules(function (rule) {
-
 			rule.walkDecls(function (decl, i) {
-
 				var value = decl.value;
 
 				/* This can't be implemented without a way to pass the current element's font size to the em calculation */
@@ -133,47 +121,33 @@ module.exports = postcss.plugin('remphiunits', function remphiunits(options) {
 				// }
 
 				// If using the syntax for px to rem
-				if (value.indexOf( px_to_rem ) !== -1) {
-
+				if (value.indexOf(px_to_rem) !== -1) {
 					// Run the replacement on this value
 					decl.value = value.replace(px_to_rem_regex, pxRemReplace);
-
 				}
 
 				// If using any of the phi conversion syntaxes
-				if (value.indexOf( phi_default ) !== -1) {
-
+				if (value.indexOf(phi_default) !== -1) {
 					// If using the syntax for phi to em value
-					if (value.indexOf( phi_to_em ) !== -1) {
-
+					if (value.indexOf(phi_to_em) !== -1) {
 						// Run the replacement on this value
 						decl.value = value.replace(phi_to_em_regex, phiEmReplace);
 
 					// If using the default syntax or phi to rem syntax
 					} else {
-
 						// If using the phi to rem syntax
-						if (value.indexOf( phi_to_rem ) !== -1) {
-
+						if (value.indexOf(phi_to_rem) !== -1) {
 							// Run the replacement on this value
 							decl.value = value.replace(phi_to_rem_regex, phiRemReplace);
 
 						// Else if using the default syntax
 						} else {
-
 							// Run the replacement on this value
 							decl.value = value.replace(phi_default_regex, phiRemReplace);
-
 						}
-
 					}
-
 				}
-
 			});
-
 		});
-
-	}
-
+	};
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import plugin from '../postcss-rem-phi-units'
+import plugin from '../postcss-rem-phi-units';
 import postcss from 'postcss';
 import { readFileSync } from 'fs';
 
@@ -7,6 +7,6 @@ test('Settingless units', async t => {
 	postcss(plugin)
 		.process(readFileSync('in.css'))
 		.then(result =>
-			t.same(result.css, readFileSync('expected.css', 'utf8'))
+			t.same(result.css, readFileSync('expected.css', 'utf8'));
 		);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,6 @@ test('Settingless units', async t => {
 	postcss(plugin)
 		.process(readFileSync('in.css'))
 		.then(result =>
-			t.same(result.css, readFileSync('expected.css', 'utf8'));
+			t.same(result.css, readFileSync('expected.css', 'utf8'))
 		);
 });


### PR DESCRIPTION
This PR adds Standard JS Happiness code style (tabs and semi-colons) and editorconfig.

Basically, just run `npm test` before pushing builds.
